### PR TITLE
Set legacy tokenizer as default

### DIFF
--- a/src/tokenizer/mod.rs
+++ b/src/tokenizer/mod.rs
@@ -4,6 +4,7 @@ mod legacy_meilisearch;
 
 pub use jieba::Jieba;
 pub use unicode_segmenter::UnicodeSegmenter;
+pub use legacy_meilisearch::LegacyMeilisearch;
 
 use crate::Token;
 use crate::processors::ProcessedText;


### PR DESCRIPTION
set legacy as default tokenizer for better compatibility with the current version of meilisearch