### PR TITLE
make stop_words optional

### DIFF
--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -116,15 +116,11 @@ where
         self.stop_words = Some(stop_words);
         self
     }
-
-    pub fn new(pipeline_map: HashMap<(Script, Language), Pipeline>, stop_words: Option<&'a Set<A>>) -> Self {
-        Self { pipeline_map, stop_words }
-    }
 }
 
 impl AnalyzerConfig<'_>
 {
-    pub fn new_with_pipeline(pipeline_map: HashMap<(Script, Language), Pipeline>) -> Self {
+    pub fn new(pipeline_map: HashMap<(Script, Language), Pipeline>) -> Self {
         Self { pipeline_map, stop_words: None }
     }
 }
@@ -317,7 +313,7 @@ mod test {
         let mut pipeline_map: HashMap<(Script, Language), Pipeline> = HashMap::new();
         pipeline_map.insert((Script::Latin, Language::Other), Pipeline::default().set_normalizer(LowercaseNormalizer));
 
-        let analyzer = Analyzer::new(AnalyzerConfig::new_with_pipeline(pipeline_map));
+        let analyzer = Analyzer::new(AnalyzerConfig::new(pipeline_map));
         let orig = "The quick (\"brown\") fox can't jump 32.3 feet, right? Brr, it's 29.3°F!";
         let analyzed = analyzer.analyze(orig);
         assert_eq!("the", analyzed.tokens().next().unwrap().text());

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -101,18 +101,37 @@ make_script! {
     Thai
 }
 
-pub struct AnalyzerConfig<'a, A> {
+pub struct AnalyzerConfig<'a, A = Vec<u8>> {
     /// language specialized tokenizer, this can be switched during
     /// document tokenization if the document contains several languages
     pub pipeline_map: HashMap<(Script, Language), Pipeline>,
-    pub stop_words: &'a Set<A>,
+    pub stop_words: Option<&'a Set<A>>,
 }
 
 impl<'a, A> AnalyzerConfig<'a, A>
 where
     A: AsRef<[u8]>,
 {
-    pub fn default_with_stopwords(stop_words: &'a Set<A>) -> Self {
+    pub fn with_stopwords(&mut self, stop_words: &'a Set<A>) -> &mut Self {
+        self.stop_words = Some(stop_words);
+        self
+    }
+
+    pub fn new(pipeline_map: HashMap<(Script, Language), Pipeline>, stop_words: Option<&'a Set<A>>) -> Self {
+        Self { pipeline_map, stop_words }
+    }
+}
+
+impl AnalyzerConfig<'_>
+{
+    pub fn new_with_pipeline(pipeline_map: HashMap<(Script, Language), Pipeline>) -> Self {
+        Self { pipeline_map, stop_words: None }
+    }
+}
+
+
+impl Default for AnalyzerConfig<'_> {
+    fn default() -> Self {
         let mut pipeline_map: HashMap<(Script, Language), Pipeline> = HashMap::new();
 
         // Latin script specialized pipeline
@@ -124,11 +143,8 @@ where
             .set_pre_processor(ChineseTranslationPreProcessor)
             .set_tokenizer(Jieba::default()));
 
-        AnalyzerConfig { pipeline_map, stop_words }
-    }
+        AnalyzerConfig { pipeline_map, stop_words: None }
 
-    pub fn new(pipeline_map: HashMap<(Script, Language), Pipeline>, stop_words: &'a Set<A>) -> Self {
-        Self { pipeline_map, stop_words }
     }
 }
 
@@ -188,7 +204,9 @@ impl<'a, A> Analyzer<'a, A> {
     /// use fst::Set;
     /// // defaults to unicode segmenter with identity preprocessor and normalizer.
     /// let stop_words = Set::from_iter([""].iter()).unwrap();
-    /// let analyzer = Analyzer::new(AnalyzerConfig::default_with_stopwords(&stop_words));
+    /// let mut config = AnalyzerConfig::default();
+    /// config.with_stopwords(&stop_words);
+    /// let analyzer = Analyzer::new(config);
     /// let analyzed = analyzer.analyze("The quick (\"brown\") fox can't jump 32.3 feet, right? Brr, it's 29.3°F!");
     /// let mut tokens = analyzed.tokens();
     /// assert!("the" == tokens.next().unwrap().text());
@@ -196,12 +214,11 @@ impl<'a, A> Analyzer<'a, A> {
     pub fn analyze<'t>(&'t self, text: &'t str) -> AnalyzedText<'t, A> {
         let pipeline = self.pipeline_from(text);
         let processed = pipeline.pre_processor.process(text);
-        let classifier = TokenClassifier::new(&self.config.stop_words);
-
+        let classifier = TokenClassifier::new(self.config.stop_words);
         AnalyzedText {
             processed,
             pipeline,
-            classifier
+            classifier,
         }
     }
 
@@ -240,8 +257,7 @@ mod test {
 
     #[test]
     fn test_simple_latin() {
-        let stop_words = Set::default();
-        let analyzer = Analyzer::new(AnalyzerConfig::default_with_stopwords(&stop_words));
+        let analyzer = Analyzer::new(AnalyzerConfig::default());
 
         let orig = "The quick (\"brown\") fox can't jump 32.3 feet, right? Brr, it's 29.3°F!";
         let analyzed = analyzer.analyze(orig);
@@ -255,8 +271,7 @@ mod test {
 
     #[test]
     fn test_simple_chinese() {
-        let stop_words = Set::default();
-        let analyzer = Analyzer::new(AnalyzerConfig::default_with_stopwords(&stop_words));
+        let analyzer = Analyzer::new(AnalyzerConfig::default());
 
         let orig = "人人生而自由﹐在尊严和权利上一律平等。他们赋有理性和良心﹐并应以兄弟关系的精神互相对待。";
         let analyzed = analyzer.analyze(orig);
@@ -269,8 +284,7 @@ mod test {
 
     #[test]
     fn test_traditional_chinese() {
-        let stop_words = Set::default();
-        let analyzer = Analyzer::new(AnalyzerConfig::default_with_stopwords(&stop_words));
+        let analyzer = Analyzer::new(AnalyzerConfig::default());
 
         let traditional = "人人生而自由﹐在尊嚴和權利上一律平等。他們賦有理性和良心﹐並應以兄弟關係的精神互相對待。";
         let _simplified = "人人生而自由﹐在尊严和权利上一律平等。他们赋有理性和良心﹐并应以兄弟关系的精神互相对待。";
@@ -285,8 +299,7 @@ mod test {
     }
     #[test]
     fn test_mixed_languages() {
-        let stop_words = Set::default();
-        let analyzer = Analyzer::new(AnalyzerConfig::default_with_stopwords(&stop_words));
+        let analyzer = Analyzer::new(AnalyzerConfig::default());
 
         let traditional = "ABB SáféRing CCCV Базовый с реле SEG WIC1, ТТ-W2+доп.катушка отключ 220 VAC+контакт сраб.реле 1НО+вывод слева+испытательные втулки. 生而自由";
 
@@ -304,8 +317,7 @@ mod test {
         let mut pipeline_map: HashMap<(Script, Language), Pipeline> = HashMap::new();
         pipeline_map.insert((Script::Latin, Language::Other), Pipeline::default().set_normalizer(LowercaseNormalizer));
 
-        let stop_words = Set::default();
-        let analyzer = Analyzer::new(AnalyzerConfig::new(pipeline_map, &stop_words));
+        let analyzer = Analyzer::new(AnalyzerConfig::new_with_pipeline(pipeline_map));
         let orig = "The quick (\"brown\") fox can't jump 32.3 feet, right? Brr, it's 29.3°F!";
         let analyzed = analyzer.analyze(orig);
         assert_eq!("the", analyzed.tokens().next().unwrap().text());
@@ -313,8 +325,7 @@ mod test {
 
     #[test]
     fn test_reconstruct_latin() {
-        let stop_words = Set::default();
-        let analyzer = Analyzer::new(AnalyzerConfig::default_with_stopwords(&stop_words));
+        let analyzer = Analyzer::new(AnalyzerConfig::default());
         let orig = "The quick (\"brown\") fox can't jump 32.3 feet, right? Brr, it's 29.3°F!";
         let tokens = analyzer.analyze(orig);
         assert_eq!(orig, tokens.reconstruct().map(|(t, _)| t).collect::<String>());
@@ -322,8 +333,7 @@ mod test {
 
     #[test]
     fn test_reconstruct_chinese() {
-        let stop_words = Set::default();
-        let analyzer = Analyzer::new(AnalyzerConfig::default_with_stopwords(&stop_words));
+        let analyzer = Analyzer::new(AnalyzerConfig::default());
         let orig = "人人生而自由﹐在尊严和权利上一律平等。他们赋有理性和良心﹐并应以兄弟关系的精神互相对待。";
         let tokens = analyzer.analyze(orig);
         assert_eq!(orig, tokens.reconstruct().map(|(t, _)| t).collect::<String>());
@@ -331,8 +341,7 @@ mod test {
 
     #[test]
     fn test_reconstruct_traditional_chinese() {
-        let stop_words = Set::default();
-        let analyzer = Analyzer::new(AnalyzerConfig::default_with_stopwords(&stop_words));
+        let analyzer = Analyzer::new(AnalyzerConfig::default());
         let traditional = "人人生而自由﹐在尊嚴和權利上一律平等。他們賦有理性和良心﹐並應以兄弟關係的精神互相對待。";
         let tokens = analyzer.analyze(traditional);
         assert_eq!(traditional, tokens.reconstruct().map(|(t, _)| t).collect::<String>());

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,11 +1,9 @@
-use fst::Set;
-
 use meilisearch_tokenizer::analyzer::{Analyzer, AnalyzerConfig};
 
 #[test]
 fn test_apostrophe_latin() {
-    let stop_words = Set::default();
-    let analyzer = Analyzer::new(AnalyzerConfig::default_with_stopwords(&stop_words));
+    let config = AnalyzerConfig::default();
+    let analyzer = Analyzer::new(config);
     let analyzed = analyzer.analyze("Zut, l’aspirateur, j’ai oublié de l’éteindre !");
     println!("{:?}", analyzed.tokens().map(|t| t.text().to_string()).collect::<Vec<_>>());
     println!("{:?}", analyzed.reconstruct().map(|(s, _)| s.to_string()).collect::<String>());

--- a/tests/token_kind.rs
+++ b/tests/token_kind.rs
@@ -6,7 +6,9 @@ use meilisearch_tokenizer::token::SeparatorKind;
 #[test]
 fn test() {
     let stop_words = Set::from_iter(["of".as_bytes(), "the".as_bytes()].iter()).unwrap();
-    let analyzer = Analyzer::new(AnalyzerConfig::default_with_stopwords(&stop_words));
+    let mut config = AnalyzerConfig::default();
+    config.with_stopwords(&stop_words);
+    let analyzer = Analyzer::new(config);
     let analyzed = analyzer.analyze("Hello, the dog.");
     let mut tokens = analyzed.tokens();
     assert!(tokens.next().unwrap().is_word());


### PR DESCRIPTION
This feature would allow us to stop creating empty fst (which are slow to create) on milli.
See https://github.com/meilisearch/milli/issues/111 