### PR TITLE
Update version for the next release (v0.2.1)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "meilisearch-tokenizer"
-version = "0.1.1"
+version = "0.2.1"
 license = "MIT"
 authors = ["Many <many@meilisearch.com>"]
 edition = "2018"


### PR DESCRIPTION
Previous release: https://github.com/meilisearch/Tokenizer/releases/tag/v0.2.0

This release will contain:
- https://github.com/meilisearch/Tokenizer/pull/41
- https://github.com/meilisearch/Tokenizer/pull/39
- https://github.com/meilisearch/Tokenizer/pull/37