### PR TITLE
Add mapping between bytes in original word and normalized word

### DIFF
--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -484,4 +484,29 @@ mod test {
         let analyzed: Vec<_> = analyzed.tokens().map(|token| token.word).collect();
         assert_eq!(analyzed, ["小", "化妆包"]);
     }
+
+    #[test]
+    fn test_grapheme_char_map() {
+        let analyzer = Analyzer::new(AnalyzerConfig::<Vec<u8>>::default());
+
+        let text = "Go💼od";
+        let analyzed = analyzer.analyze(text);
+        let mut analyzed = analyzed.tokens();
+        let token = analyzed.next().unwrap();
+
+        let num_chars = token.num_graphemes_from_bytes(11);
+        assert_eq!(num_chars, 3);
+
+        let num_chars = token.num_graphemes_from_bytes(10);
+        assert_eq!(num_chars, 3);
+
+        let num_chars = token.num_graphemes_from_bytes(2);
+        assert_eq!(num_chars, 2);
+
+        let num_chars = token.num_graphemes_from_bytes(1);
+        assert_eq!(num_chars, 1);
+
+        let num_chars = token.num_graphemes_from_bytes(13);
+        assert_eq!(num_chars, 5);
+    }
 }

--- a/src/normalizer/deunicoder.rs
+++ b/src/normalizer/deunicoder.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 
 use deunicode::deunicode;
+use unicode_segmentation::UnicodeSegmentation;
 
 use super::Normalizer;
 use crate::Token;
@@ -26,7 +27,13 @@ impl Default for DeunicodeNormalizer {
 impl Normalizer for DeunicodeNormalizer {
     fn normalize<'a>(&self, mut token: Token<'a>) -> Token<'a> {
         if !(self.skip_normalization)(&token.word) {
-            token.word = Cow::Owned(deunicode(token.word.as_ref()));
+            let mut char_map = Vec::new();
+            for grapheme in token.word.graphemes(true) {
+                char_map.push(deunicode(grapheme).len());
+            }
+            let deunicoded = deunicode(token.word.as_ref());
+            token.word = Cow::Owned(deunicoded);
+            token.char_map = Some(char_map);
         }
 
         token

--- a/src/normalizer/mod.rs
+++ b/src/normalizer/mod.rs
@@ -42,6 +42,7 @@ mod test {
             kind: TokenKind::Word,
             byte_start: 0,
             byte_end: 0,
+            char_map: None,
         };
 
         let token_l = LowercaseNormalizer.normalize(token.clone());
@@ -67,6 +68,7 @@ mod test {
             kind: TokenKind::Word,
             byte_start: 0,
             byte_end: 0,
+            char_map: None,
         };
 
         let deunicoder = DeunicodeNormalizer::new(&|text: &str| {

--- a/src/token.rs
+++ b/src/token.rs
@@ -34,6 +34,9 @@ pub struct Token<'a> {
     /// indexes of start and end of the byte slice
     pub byte_start: usize,
     pub byte_end: usize,
+    /// number of bytes used in the normalized string
+    ///  by each grapheme cluster in the original string
+    pub char_map: Option<Vec<usize>>,
 }
 
 impl<'a> PartialEq for Token<'a> {
@@ -68,5 +71,23 @@ impl<'a> Token<'a> {
     }
     pub fn is_stopword(&self) -> bool {
         self.kind == TokenKind::StopWord
+    }
+
+    pub fn num_graphemes_from_bytes(&self, mut num_bytes: usize) -> usize {
+        match &self.char_map {
+            None => self.word.len(),
+            Some(char_map) => {
+                let mut count = 0;
+                while num_bytes > 0 {
+                    if char_map.len() > count {
+                        num_bytes -= char_map[count];
+                        count += 1;
+                    } else {
+                        break;
+                    }
+                }
+                count
+            }
+        }
     }
 }

--- a/src/token.rs
+++ b/src/token.rs
@@ -76,18 +76,15 @@ impl<'a> Token<'a> {
     pub fn num_graphemes_from_bytes(&self, mut num_bytes: usize) -> usize {
         match &self.char_map {
             None => self.word.len(),
-            Some(char_map) => {
-                let mut count = 0;
-                while num_bytes > 0 {
-                    if char_map.len() > count {
-                        num_bytes -= char_map[count];
-                        count += 1;
-                    } else {
-                        break;
-                    }
-                }
-                count
-            }
+            Some(char_map) => char_map
+                .iter()
+                .cloned()
+                .take_while(|bytes_in_char| {
+                    let prev = num_bytes;
+                    num_bytes = num_bytes.saturating_sub(*bytes_in_char);
+                    prev > 0
+                })
+                .count(),
         }
     }
 }

--- a/src/token.rs
+++ b/src/token.rs
@@ -73,6 +73,17 @@ impl<'a> Token<'a> {
         self.kind == TokenKind::StopWord
     }
 
+    /// Returns the number of graphemes in original token using number of characters in normalized
+    /// token.
+    ///
+    /// Grapheme clusters are counted in the pre-processed string (just before normalizing).
+    /// For example, consider the string "Go💼od" which gets normalized to "gobriefcase od".
+    /// `num_graphemes_from_bytes(11)` for this token will return `3` - the number of characters in
+    /// the original string for 11 bytes in the normalized string.
+    ///
+    /// # Arguments
+    ///
+    /// * `num_bytes` - number of bytes in normalized token
     pub fn num_graphemes_from_bytes(&self, mut num_bytes: usize) -> usize {
         match &self.char_map {
             None => self.word.len(),

--- a/src/tokenizer/jieba.rs
+++ b/src/tokenizer/jieba.rs
@@ -55,6 +55,7 @@ impl Tokenizer for Jieba {
                     char_index: char_start,
                     byte_start,
                     byte_end,
+                    char_map: None,
                 })
             })),
         }

--- a/src/tokenizer/legacy_meilisearch.rs
+++ b/src/tokenizer/legacy_meilisearch.rs
@@ -43,6 +43,7 @@ impl<'a> Iterator for LegacyTokenizer<'a> {
             char_index: self.char_index,
             byte_start: self.byte_index,
             byte_end: self.byte_index + word.len(),
+            char_map: None,
         });
 
         self.char_index += word.chars().count();

--- a/src/tokenizer/unicode_segmenter.rs
+++ b/src/tokenizer/unicode_segmenter.rs
@@ -21,6 +21,7 @@ impl Tokenizer for UnicodeSegmenter {
                     byte_start: byte_index,
                     char_index: index,
                     byte_end: byte_index + word.len(),
+                    char_map: None,
                 })
             },
         );


### PR DESCRIPTION
# Pull Request

## What does this PR do?

Towards fixing meilisearch/tokenizer#54

 - Added a `char_map` vector in Token
 - It stores the number of bytes in the normalized word for each grapheme cluster (character) in the original word
 - To use it in a highlighter, given the number of bytes to highlight, use the `num_graphemes_from_bytes` fn to get the number of chars to highlight.
    - Though, note that the meilisearch highlighter only gets the raw string (&str) instead of the token struct. Hence it will need major changes in the highlighter, or an alternate solution here.
 - It must also be noted that this adds a significant overhead to tokenization as a new vector is stored for *every* token.
    - and `deunicode` has to be run twice on the same token - once for each grapheme cluster and once for the entire word.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

This is my first Rust PR :smile:, please let me know if something's not right