### PR TITLE
Please exclude Hangul from is_cjk.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ meilisearch-core/target
 /query-history.txt
 /data.ms
 Cargo.lock
+.idea

--- a/benches/initialization.rs
+++ b/benches/initialization.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use criterion::{BenchmarkId, Criterion};
 use fst::Set;
 use meilisearch_tokenizer::analyzer::{Language, Pipeline, Script};
-use meilisearch_tokenizer::detection::is_cjk;
+use meilisearch_tokenizer::detection::is_cj;
 use meilisearch_tokenizer::normalizer::{DeunicodeNormalizer, LowercaseNormalizer, Normalizer};
 use meilisearch_tokenizer::processors::ChineseTranslationPreProcessor;
 use meilisearch_tokenizer::tokenizer::{Jieba, LegacyMeilisearch};
@@ -62,7 +62,7 @@ fn legacy_tok_deunicode_lowercase_norm(text: &str) {
 fn translation_pre_jieba_tok_deunicode_lowercase_norm(text: &str) {
     let mut pipeline_map: HashMap<(Script, Language), Pipeline> = HashMap::new();
     let chinese_deunicoder =
-        DeunicodeNormalizer::new(&|text: &str| text.chars().next().map_or(false, is_cjk));
+        DeunicodeNormalizer::new(&|text: &str| text.chars().next().map_or(false, is_cj));
     let chinese_normalizer: Vec<Box<dyn Normalizer>> =
         vec![Box::new(chinese_deunicoder), Box::new(LowercaseNormalizer)];
     pipeline_map.insert(

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -431,6 +431,7 @@ mod test {
         let analyzer = Analyzer::new(AnalyzerConfig::<Vec<u8>>::default());
         let orig = "The quick (\"brown\") fox can't jump 32.3 feet, right? Brr, it's 29.3°F!";
         let tokens = analyzer.analyze(orig);
+        println!("{:?}", tokens.tokens().map(|t| t.text().to_string()).collect::<Vec<_>>());
         assert_eq!(orig, tokens.reconstruct().map(|(t, _)| t).collect::<String>());
     }
 
@@ -439,6 +440,16 @@ mod test {
         let analyzer = Analyzer::new(AnalyzerConfig::<Vec<u8>>::default());
         let orig = "人人生而自由﹐在尊严和权利上一律平等。他们赋有理性和良心﹐并应以兄弟关系的精神互相对待。";
         let tokens = analyzer.analyze(orig);
+        println!("{:?}", tokens.tokens().map(|t| t.text().to_string()).collect::<Vec<_>>());
+        assert_eq!(orig, tokens.reconstruct().map(|(t, _)| t).collect::<String>());
+    }
+
+    #[test]
+    fn test_reconstruct_korean() {
+        let analyzer = Analyzer::new(AnalyzerConfig::<Vec<u8>>::default());
+        let orig = "안녕하세요. 한의계에 새로운 흐름을 만들어갑니다.";
+        let tokens = analyzer.analyze(orig);
+        println!("{:?}", tokens.tokens().map(|t| t.text().to_string()).collect::<Vec<_>>());
         assert_eq!(orig, tokens.reconstruct().map(|(t, _)| t).collect::<String>());
     }
 

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -431,7 +431,6 @@ mod test {
         let analyzer = Analyzer::new(AnalyzerConfig::<Vec<u8>>::default());
         let orig = "The quick (\"brown\") fox can't jump 32.3 feet, right? Brr, it's 29.3°F!";
         let tokens = analyzer.analyze(orig);
-        println!("{:?}", tokens.tokens().map(|t| t.text().to_string()).collect::<Vec<_>>());
         assert_eq!(orig, tokens.reconstruct().map(|(t, _)| t).collect::<String>());
     }
 
@@ -440,7 +439,6 @@ mod test {
         let analyzer = Analyzer::new(AnalyzerConfig::<Vec<u8>>::default());
         let orig = "人人生而自由﹐在尊严和权利上一律平等。他们赋有理性和良心﹐并应以兄弟关系的精神互相对待。";
         let tokens = analyzer.analyze(orig);
-        println!("{:?}", tokens.tokens().map(|t| t.text().to_string()).collect::<Vec<_>>());
         assert_eq!(orig, tokens.reconstruct().map(|(t, _)| t).collect::<String>());
     }
 
@@ -449,7 +447,6 @@ mod test {
         let analyzer = Analyzer::new(AnalyzerConfig::<Vec<u8>>::default());
         let orig = "안녕하세요. 한의계에 새로운 흐름을 만들어갑니다.";
         let tokens = analyzer.analyze(orig);
-        println!("{:?}", tokens.tokens().map(|t| t.text().to_string()).collect::<Vec<_>>());
         assert_eq!(orig, tokens.reconstruct().map(|(t, _)| t).collect::<String>());
     }
 

--- a/src/detection.rs
+++ b/src/detection.rs
@@ -3,20 +3,15 @@ use deunicode::deunicode_char;
 use crate::token::SeparatorKind;
 
 pub fn is_cjk(c: char) -> bool {
-    (c >= '\u{1100}' && c <= '\u{11ff}')  // Hangul Jamo
-        || (c >= '\u{2e80}' && c <= '\u{2eff}')  // CJK Radicals Supplement
+    (c >= '\u{2e80}' && c <= '\u{2eff}')  // CJK Radicals Supplement
         || (c >= '\u{2f00}' && c <= '\u{2fdf}') // Kangxi radical
         || (c >= '\u{3000}' && c <= '\u{303f}') // Japanese-style punctuation
         || (c >= '\u{3040}' && c <= '\u{309f}') // Japanese Hiragana
         || (c >= '\u{30a0}' && c <= '\u{30ff}') // Japanese Katakana
         || (c >= '\u{3100}' && c <= '\u{312f}')
-        || (c >= '\u{3130}' && c <= '\u{318F}') // Hangul Compatibility Jamo
         || (c >= '\u{3200}' && c <= '\u{32ff}') // Enclosed CJK Letters and Months
         || (c >= '\u{3400}' && c <= '\u{4dbf}') // CJK Unified Ideographs Extension A
         || (c >= '\u{4e00}' && c <= '\u{9fff}') // CJK Unified Ideographs
-        || (c >= '\u{a960}' && c <= '\u{a97f}') // Hangul Jamo Extended-A
-        || (c >= '\u{ac00}' && c <= '\u{d7a3}') // Hangul Syllables
-        || (c >= '\u{d7b0}' && c <= '\u{d7ff}') // Hangul Jamo Extended-B
         || (c >= '\u{f900}' && c <= '\u{faff}') // CJK Compatibility Ideographs
         || (c >= '\u{ff00}' && c <= '\u{ffef}') // Full-width roman characters and half-width katakana
 }

--- a/src/detection.rs
+++ b/src/detection.rs
@@ -2,7 +2,7 @@ use deunicode::deunicode_char;
 
 use crate::token::SeparatorKind;
 
-pub fn is_cjk(c: char) -> bool {
+pub fn is_cj(c: char) -> bool {
     (c >= '\u{2e80}' && c <= '\u{2eff}')  // CJK Radicals Supplement
         || (c >= '\u{2f00}' && c <= '\u{2fdf}') // Kangxi radical
         || (c >= '\u{3000}' && c <= '\u{303f}') // Japanese-style punctuation
@@ -14,6 +14,14 @@ pub fn is_cjk(c: char) -> bool {
         || (c >= '\u{4e00}' && c <= '\u{9fff}') // CJK Unified Ideographs
         || (c >= '\u{f900}' && c <= '\u{faff}') // CJK Compatibility Ideographs
         || (c >= '\u{ff00}' && c <= '\u{ffef}') // Full-width roman characters and half-width katakana
+}
+
+pub fn is_hangul(c: char) -> bool {
+    (c >= '\u{1100}' && c <= '\u{11ff}')  // Hangul Jamo
+        || (c >= '\u{3130}' && c <= '\u{318F}') // Hangul Compatibility Jamo
+        || (c >= '\u{a960}' && c <= '\u{a97f}') // Hangul Jamo Extended-A
+        || (c >= '\u{ac00}' && c <= '\u{d7a3}') // Hangul Syllables
+        || (c >= '\u{d7b0}' && c <= '\u{d7ff}') // Hangul Jamo Extended-B
 }
 
 // https://en.wikipedia.org/wiki/Latin_script_in_Unicode

--- a/src/detection.rs
+++ b/src/detection.rs
@@ -16,6 +16,7 @@ pub fn is_cj(c: char) -> bool {
         || (c >= '\u{ff00}' && c <= '\u{ffef}') // Full-width roman characters and half-width katakana
 }
 
+#[allow(dead_code)]
 pub fn is_hangul(c: char) -> bool {
     (c >= '\u{1100}' && c <= '\u{11ff}')  // Hangul Jamo
         || (c >= '\u{3130}' && c <= '\u{318F}') // Hangul Compatibility Jamo

--- a/src/normalizer/mod.rs
+++ b/src/normalizer/mod.rs
@@ -31,7 +31,7 @@ mod test {
     use std::borrow::Cow;
 
     use super::*;
-    use crate::detection::is_cjk;
+    use crate::detection::is_cj;
     use crate::TokenKind;
 
     #[test]
@@ -70,7 +70,7 @@ mod test {
         };
 
         let deunicoder = DeunicodeNormalizer::new(&|text: &str| {
-            text.chars().next().map_or(false, |c| is_cjk(c))
+            text.chars().next().map_or(false, |c| is_cj(c))
         });
 
         let token_l = LowercaseNormalizer.normalize(token.clone());

--- a/src/tokenizer/legacy_meilisearch.rs
+++ b/src/tokenizer/legacy_meilisearch.rs
@@ -4,6 +4,7 @@ use slice_group_by::StrGroupBy;
 
 use super::{TokenStream, Tokenizer};
 use crate::detection::classify_separator;
+use crate::detection::is_cj;
 use crate::processors::ProcessedText;
 use crate::token::SeparatorKind;
 use crate::{Token, TokenKind};
@@ -56,29 +57,15 @@ impl<'a> Iterator for LegacyTokenizer<'a> {
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 enum CharCategory {
     Separator(SeparatorKind),
-    Cjk,
+    Cj,
     Other,
-}
-
-pub fn is_cjk(c: char) -> bool {
-     (c >= '\u{2e80}' && c <= '\u{2eff}')  // CJK Radicals Supplement
-        || (c >= '\u{2f00}' && c <= '\u{2fdf}') // Kangxi radical
-        || (c >= '\u{3000}' && c <= '\u{303f}') // Japanese-style punctuation
-        || (c >= '\u{3040}' && c <= '\u{309f}') // Japanese Hiragana
-        || (c >= '\u{30a0}' && c <= '\u{30ff}') // Japanese Katakana
-        || (c >= '\u{3100}' && c <= '\u{312f}')
-        || (c >= '\u{3200}' && c <= '\u{32ff}') // Enclosed CJK Letters and Months
-        || (c >= '\u{3400}' && c <= '\u{4dbf}') // CJK Unified Ideographs Extension A
-        || (c >= '\u{4e00}' && c <= '\u{9fff}') // CJK Unified Ideographs
-        || (c >= '\u{f900}' && c <= '\u{faff}') // CJK Compatibility Ideographs
-        || (c >= '\u{ff00}' && c <= '\u{ffef}') // Full-width roman characters and half-width katakana
 }
 
 fn classify_char(c: char) -> CharCategory {
     if let Some(category) = classify_separator(c) {
         CharCategory::Separator(category)
-    } else if is_cjk(c) {
-        CharCategory::Cjk
+    } else if is_cj(c) {
+        CharCategory::Cj
     } else {
         CharCategory::Other
     }
@@ -86,7 +73,7 @@ fn classify_char(c: char) -> CharCategory {
 
 fn same_group_category(a: char, b: char) -> bool {
     match (classify_char(a), classify_char(b)) {
-        (CharCategory::Cjk, _) | (_, CharCategory::Cjk) => false,
+        (CharCategory::Cj, _) | (_, CharCategory::Cj) => false,
         (CharCategory::Separator(_), CharCategory::Separator(_)) => true,
         (a, b) => a == b,
     }

--- a/src/tokenizer/legacy_meilisearch.rs
+++ b/src/tokenizer/legacy_meilisearch.rs
@@ -61,20 +61,15 @@ enum CharCategory {
 }
 
 pub fn is_cjk(c: char) -> bool {
-    (c >= '\u{1100}' && c <= '\u{11ff}')  // Hangul Jamo
-        || (c >= '\u{2e80}' && c <= '\u{2eff}')  // CJK Radicals Supplement
+     (c >= '\u{2e80}' && c <= '\u{2eff}')  // CJK Radicals Supplement
         || (c >= '\u{2f00}' && c <= '\u{2fdf}') // Kangxi radical
         || (c >= '\u{3000}' && c <= '\u{303f}') // Japanese-style punctuation
         || (c >= '\u{3040}' && c <= '\u{309f}') // Japanese Hiragana
         || (c >= '\u{30a0}' && c <= '\u{30ff}') // Japanese Katakana
         || (c >= '\u{3100}' && c <= '\u{312f}')
-        || (c >= '\u{3130}' && c <= '\u{318F}') // Hangul Compatibility Jamo
         || (c >= '\u{3200}' && c <= '\u{32ff}') // Enclosed CJK Letters and Months
         || (c >= '\u{3400}' && c <= '\u{4dbf}') // CJK Unified Ideographs Extension A
         || (c >= '\u{4e00}' && c <= '\u{9fff}') // CJK Unified Ideographs
-        || (c >= '\u{a960}' && c <= '\u{a97f}') // Hangul Jamo Extended-A
-        || (c >= '\u{ac00}' && c <= '\u{d7a3}') // Hangul Syllables
-        || (c >= '\u{d7b0}' && c <= '\u{d7ff}') // Hangul Jamo Extended-B
         || (c >= '\u{f900}' && c <= '\u{faff}') // CJK Compatibility Ideographs
         || (c >= '\u{ff00}' && c <= '\u{ffef}') // Full-width roman characters and half-width katakana
 }


### PR DESCRIPTION
Please exclude Hangul from is_cjk.

Because Hangul is a complex language, tokenizering like English has much better results than separating Hangul characters like Chinese characters.

I introduced meilisearch to the company except for Hangul in is_cjk.
It's about to be released.
