### PR TITLE
Count chars instead of graphemes and fix return value when `char_map` is uninitialized

### DIFF
--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -511,6 +511,9 @@ mod test {
         let num_chars = token.num_chars_from_bytes(10);
         assert_eq!(num_chars, 3);
 
+        let num_chars = token.num_chars_from_bytes(9);
+        assert_eq!(num_chars, 3);
+
         let num_chars = token.num_chars_from_bytes(2);
         assert_eq!(num_chars, 2);
 
@@ -563,8 +566,9 @@ mod test {
         let num_chars = token.num_chars_from_bytes(2);
         assert_eq!(num_chars, 2);
 
+        // consider the char even if only a part of it is available.
         let num_chars = token.num_chars_from_bytes(3);
-        assert_eq!(num_chars, 2);
+        assert_eq!(num_chars, 3);
 
         let num_chars = token.num_chars_from_bytes(6);
         assert_eq!(num_chars, 3);

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -253,7 +253,8 @@ mod test {
     use std::borrow::Cow;
 
     use super::*;
-    use crate::{normalizer::LowercaseNormalizer, TokenKind};
+    use crate::normalizer::LowercaseNormalizer;
+    use crate::TokenKind;
 
     #[test]
     fn test_simple_latin() {
@@ -531,8 +532,21 @@ mod test {
             char_map: None,
         };
 
+
+        let num_chars = token.num_chars_from_bytes(0);
+        assert_eq!(num_chars, 0);
+
+        let num_chars = token.num_chars_from_bytes(1);
+        assert_eq!(num_chars, 1);
+
+        let num_chars = token.num_chars_from_bytes(2);
+        assert_eq!(num_chars, 2);
+
         let num_chars = token.num_chars_from_bytes(3);
         assert_eq!(num_chars, 3);
+
+        let num_chars = token.num_chars_from_bytes(4);
+        assert_eq!(num_chars, 4);
 
         let token = Token {
             kind: TokenKind::Word,
@@ -543,6 +557,9 @@ mod test {
             char_map: None,
         };
 
+        let num_chars = token.num_chars_from_bytes(1);
+        assert_eq!(num_chars, 1);
+
         let num_chars = token.num_chars_from_bytes(2);
         assert_eq!(num_chars, 2);
 
@@ -551,5 +568,11 @@ mod test {
 
         let num_chars = token.num_chars_from_bytes(6);
         assert_eq!(num_chars, 3);
+
+        let num_chars = token.num_chars_from_bytes(7);
+        assert_eq!(num_chars, 4);
+
+        let num_chars = token.num_chars_from_bytes(8);
+        assert_eq!(num_chars, 5);
     }
 }

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -250,8 +250,10 @@ impl<'a, A> Analyzer<'a, A> {
 
 #[cfg(test)]
 mod test {
+    use std::borrow::Cow;
+
     use super::*;
-    use crate::normalizer::LowercaseNormalizer;
+    use crate::{normalizer::LowercaseNormalizer, TokenKind};
 
     #[test]
     fn test_simple_latin() {
@@ -494,7 +496,7 @@ mod test {
     }
 
     #[test]
-    fn test_grapheme_char_map() {
+    fn test_num_chars_from_bytes() {
         let analyzer = Analyzer::new(AnalyzerConfig::<Vec<u8>>::default());
 
         let text = "Go💼od";
@@ -502,19 +504,52 @@ mod test {
         let mut analyzed = analyzed.tokens();
         let token = analyzed.next().unwrap();
 
-        let num_chars = token.num_graphemes_from_bytes(11);
+        let num_chars = token.num_chars_from_bytes(11);
         assert_eq!(num_chars, 3);
 
-        let num_chars = token.num_graphemes_from_bytes(10);
+        let num_chars = token.num_chars_from_bytes(10);
         assert_eq!(num_chars, 3);
 
-        let num_chars = token.num_graphemes_from_bytes(2);
+        let num_chars = token.num_chars_from_bytes(2);
         assert_eq!(num_chars, 2);
 
-        let num_chars = token.num_graphemes_from_bytes(1);
+        let num_chars = token.num_chars_from_bytes(1);
         assert_eq!(num_chars, 1);
 
-        let num_chars = token.num_graphemes_from_bytes(13);
+        let num_chars = token.num_chars_from_bytes(13);
         assert_eq!(num_chars, 5);
+    }
+
+    #[test]
+    fn test_num_chars_from_bytes_uninitialized() {
+        let token = Token {
+            kind: TokenKind::Word,
+            word: Cow::Borrowed("word"),
+            byte_start: 0,
+            char_index: 0,
+            byte_end: "word".len(),
+            char_map: None,
+        };
+
+        let num_chars = token.num_chars_from_bytes(3);
+        assert_eq!(num_chars, 3);
+
+        let token = Token {
+            kind: TokenKind::Word,
+            word: Cow::Borrowed("Go💼od"),
+            byte_start: 0,
+            char_index: 0,
+            byte_end: "Go💼od".len(),
+            char_map: None,
+        };
+
+        let num_chars = token.num_chars_from_bytes(2);
+        assert_eq!(num_chars, 2);
+
+        let num_chars = token.num_chars_from_bytes(3);
+        assert_eq!(num_chars, 2);
+
+        let num_chars = token.num_chars_from_bytes(6);
+        assert_eq!(num_chars, 3);
     }
 }

--- a/src/token.rs
+++ b/src/token.rs
@@ -86,7 +86,7 @@ impl<'a> Token<'a> {
     /// * `num_bytes` - number of bytes in normalized token
     pub fn num_graphemes_from_bytes(&self, mut num_bytes: usize) -> usize {
         match &self.char_map {
-            None => self.word.len(),
+            None => num_bytes,
             Some(char_map) => char_map
                 .iter()
                 .cloned()


### PR DESCRIPTION
~When used with `num_bytes` smaller than the length of the string and when the Token does not have a char_map (created outside of the tokenizer perhaps), the output of `num_graphemes_from_bytes` was wrong - it would return the length of the internal string instead of the number of bytes that was asked.~

Changed `num_graphemes_from_bytes` to `num_chars_from_bytes` because:
- counting graphemes is slower
- graphemes require an external dependency
- only chars are needed for highlighting (which is the intended usage of this function)

When the `char_map` was not initialized (created outside of the tokenizer perhaps), the output of this function was wrong - it would return the length of the internal string instead of the number of bytes that was asked. Fixed this to count the number of chars for given number of bytes, in the string that is available (could be de-unicoded).

# Pull Request

## What does this PR do?
Fixes #63 
<!-- Please link the issue you're trying to fix with this PR, if none then please create an issue first. -->

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?
