### PR TITLE
Decompose Japanese compound words

### DIFF
--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -708,6 +708,6 @@ mod test {
         let orig = "関西国際空港限定トートバッグ";
         let analyzed = analyzer.analyze(orig);
         let analyzed: Vec<_> = analyzed.tokens().map(|token| token.word).collect();
-        assert_eq!(analyzed, ["関西国際空港", "限定", "トートバッグ"]);
+        assert_eq!(analyzed, ["関西", "国際", "空港", "限定", "トートバッグ"]);
     }
 }

--- a/src/tokenizer/lindera.rs
+++ b/src/tokenizer/lindera.rs
@@ -1,13 +1,18 @@
 use std::borrow::Cow;
 
-use lindera::tokenizer::Tokenizer as LinderaTokenizer;
+use lindera::tokenizer::{Tokenizer as LinderaTokenizer, TokenizerConfig};
+use lindera_core::viterbi::{Mode, Penalty};
 use once_cell::sync::Lazy;
 
 use super::{TokenStream, Tokenizer};
 use crate::processors::ProcessedText;
 use crate::{Token, TokenKind};
 
-static LINDERA: Lazy<LinderaTokenizer> = Lazy::new(|| LinderaTokenizer::new().unwrap());
+static LINDERA: Lazy<LinderaTokenizer> = Lazy::new(|| {
+    let config =
+        TokenizerConfig { mode: Mode::Decompose(Penalty::default()), ..TokenizerConfig::default() };
+    LinderaTokenizer::with_config(config).unwrap()
+});
 
 #[derive(Debug, Default)]
 pub struct Lindera;
@@ -69,7 +74,7 @@ mod test {
             .tokenize(&processed)
             .map(|Token { word, .. }| word.to_owned())
             .collect::<Vec<_>>();
-        assert_eq!(tokens, ["関西国際空港", "限定", "トートバッグ"]);
+        assert_eq!(tokens, ["関西", "国際", "空港", "限定", "トートバッグ"]);
 
         let orig = "すもももももももものうち";
         let processed = ProcessedText { original: orig, processed: Cow::Borrowed(orig) };
@@ -119,7 +124,7 @@ mod test {
             .tokenize(&processed)
             .map(|Token { char_index, .. }| char_index)
             .collect::<Vec<_>>();
-        assert_eq!(positions, [0, 6, 8]);
+        assert_eq!(positions, [0, 2, 4, 6, 8]);
 
         let orig = "すもももももももものうち";
         let processed = ProcessedText { original: orig, processed: Cow::Borrowed(orig) };


### PR DESCRIPTION
# Pull Request

The morphological dictionary that Lindera includes by default is IPADIC.
IPADIC includes many compound words. For example, `関西国際空港` (Kansai International Airport). 
However, if you index in the default mode, the word `関西国際空港` (Kansai International Airport) will be indexed in the term `関西国際空港`, and you will not be able to search for the keyword `空港` (Airport).
So, Lindera has a function to decompose such compound words.
This is a feature similar to [Kuromoji's search mode](https://lucene.apache.org/core/9_0_0/analysis/kuromoji/org/apache/lucene/analysis/ja/JapaneseTokenizer.Mode.html#SEARCH).

## What does this PR do?
Fixes #74
<!-- Please link the issue you're trying to fix with this PR, if none then please create an issue first. -->

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
