### PR TITLE
Update the dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,19 +7,19 @@ edition = "2018"
 
 [dependencies]
 character_converter = "1.0.0"
-cow-utils = "0.1"
-deunicode = "1.1.1"
-fst = "0.4"
-jieba-rs = "0.6"
-once_cell = "1.5.2"
-slice-group-by = "0.2.6"
-unicode-segmentation = "1.6.0"
-whatlang = "0.12.0"
+cow-utils = "0.1.2"
+deunicode = "1.3.1"
+fst = "0.4.7"
+jieba-rs = "0.6.6"
+once_cell = "1.10.0"
+slice-group-by = "0.3.0"
+unicode-segmentation = "1.9.0"
+whatlang = "0.13.0"
 lindera = "0.10.0"
 lindera-core = "0.10.0"
 
 [dev-dependencies]
-criterion = "0.3"
+criterion = "0.3.5"
 
 [[bench]]
 name = "bench"

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -142,8 +142,8 @@ make_language! {
     Afr,
     Lat,
     Slk,
-    Cat
-    // Tgl  added in whatlang 0.13.0
+    Cat,
+    Tgl
 }
 
 macro_rules! make_script {


### PR DESCRIPTION
This PR upgrades and updates the dependencies of the tokenizer. However, I wasn't able to bump `lindera` and `lindera-core` to _0.11_ as I encountered _once_cell_ poisoned issues.

@ManyTheFish Do you think we can create a new release of the tokenizer, something like a v0.2.8? Bumping dependencies is not breaking, here.